### PR TITLE
new(community): add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,5 @@
 <!-- https://help.github.com/en/github/building-a-strong-community/adding-a-code-of-conduct-to-your-project -->
+<p align="center">&#x26A0;&#xFE0E; This is a living document &mdash; it can evolve over time.</p>
 
 # Code of Conduct
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+<!-- https://help.github.com/en/github/building-a-strong-community/adding-a-code-of-conduct-to-your-project -->
+
+# Code of Conduct
+
+_Be excellent to each other._
+
+We expect OpenINF community members to act professionally and respectfully, and
+we expect our social spaces to be safe and dignified environments.
+
+Specifically:
+
+- Respect people, their identities, their culture, and their work.
+- Listen. Consider and acknowledge people’s points before responding.


### PR DESCRIPTION
Since I hope to be able to use [a `.github` repo](https://github.blog/changelog/2019-02-21-organization-wide-community-health-files/) for all of our organization-wide meta files, I would like to be able to move this file, along with all of our other organization-wide meta files contained in the [openinf/openinf.github.io](https://github.com/openinf/openinf.github.io) repo, which is currently the source of truth on the matter. I plan to de-duplicate them from all of our other repos once this gets merged here so that we only need to maintain a single set of these in a single repo. This should be a good place to keep all of them while we are on GitHub since it should be helpful to contributors in all of our other repos without having to keep them in our source tree.

Now would be a good time to discuss whether we have any changes we would like to make to this file in particular. There are probably some good ideas to be incorporated from other codes of conduct like the [Berlin Code of Conduct](https://berlincodeofconduct.org/), which most recently influenced this file by removing a line we had about vague-kindness (thanks to @skade recently calling it out on Twitter). @emmitrovic thought that the Berlin Code of Conduct looked good to her, but that maybe it had too much text. After looking at it again myself, I think a lot of the language it contains regarding in-person interactions are probably mostly irrelevant for our case as most interactions with our community will be done remotely as contributors will be from around the globe.

Another thing we are missing is a Moderation Policy, which is typically mentioned in this document, but we can include it later if it helps things move along more quickly. @yuvilio mentioned to me earlier that he'd be interested in moderating, so I am glad we have someone to step up for that role already. We should probably have his thoughts on that since he will likely be enforcing it, but we may want to keep this PR more focused on the one file for now.