### PR TITLE
new(contrib,doc): add org-level default CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,8 +100,8 @@ on Twitter.
 
 ## Code of Conduct
 
-By participating in this project, you are expected to uphold our [Code of
-Conduct][code_of_conduct].
+By participating in this project, you are expected to uphold our Code of
+Conduct. Please see the [`CODE_OF_CONDUCT.md`] file for expected behavior.
 
 ## Developer’s Certificate of Origin 1.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ The [`README.md`] in the root of the repository should contain or link to
 project documentation. If you cannot find the documentation you’re looking for,
 please file a GitHub issue with details of what you’d like to see documented.
 
-## Questions or thoughts?
+## Questions or Thoughts?
 
 Support requests (e.g., asking questions) or feedback (e.g., constructive
 criticism) may be directed to the [`@OpenINF`][twitter-account] support account

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ Please see the [`SECURITY.md`][] file.
   ./CODE_OF_CONDUCT.md
   'Standards for how to engage with the project community'
 [`CONTRIBUTING.md`]: ./CONTRIBUTING.md 'Contribution guidelines for this project'
-[`funding`]:
+[`FUNDING.yml`]:
   ./.github/FUNDING.yml
   'How to financially support maintenance/development of @OpenINF projects on GitHub using GitHub Sponsors'
 [`license`]:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ Please see the [`SECURITY.md`][] file.
   ./LICENSE
   'The open source software license(s) associated with this project'
 [`README.md`]: ./README.md 'The landing/home page of this project'
-[`security`]:
+[`SECURITY.md`]:
   ./SECURITY.md
   'Instructions on how to report security vulnerabilities for this project'
 [`support`]: ./SUPPORT.md 'Where to get help on this project'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ details and the rationale for the proposed change.
 
 ## Pull Requests
 
-If you’d like to propose and collaborate on changes, open a [pull request][]!
+If you’d like to propose and collaborate on changes, open a [pull request]!
 
 Here are a few things you can do that will increase the likelihood of having
 your pull request merged:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ Please see the [`SECURITY.md`][] file.
 [`FUNDING.yml`]:
   ./.github/FUNDING.yml
   'How to financially support maintenance/development of @OpenINF projects on GitHub using GitHub Sponsors'
-[`license`]:
+[`LICENSE`]:
   ./LICENSE
   'The open source software license(s) associated with this project'
 [`readme`]: ./README.md 'The landing/home page of this project'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ Please see the [`SECURITY.md`] file.
 [`authors`]:
   https://github.com/openinf/.github/blob/HEAD/AUTHORS
   'List of people who have contributed code to this project'
-[`code_of_conduct`]:
+[`CODE_OF_CONDUCT.md`]:
   ./CODE_OF_CONDUCT.md
   'Standards for how to engage with the project community'
 [`contributing`]: ./CONTRIBUTING.md 'Contribution guidelines for this project'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Contributions to this project are [released][contrib-license] to the public
 under the project’s open source license. The license for a project is located in
 a file named `LICENSE` in the root directory of the repository.
 
-## Project documentation
+## Project Documentation
 
 The [`README.md`] in the root of the repository should contain or link to
 project documentation. If you cannot find the documentation you’re looking for,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Support requests (e.g., asking questions) or feedback (e.g., constructive
 criticism) may be directed to the [`@OpenINF`][twitter-account] support account
 on Twitter.
 
-## Additional resources
+## Additional Resources
 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 - [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ Please see the [`SECURITY.md`][] file.
 [`CODE_OF_CONDUCT.md`]:
   ./CODE_OF_CONDUCT.md
   'Standards for how to engage with the project community'
-[`CONTRIBUTING`]: ./CONTRIBUTING.md 'Contribution guidelines for this project'
+[`CONTRIBUTING.md`]: ./CONTRIBUTING.md 'Contribution guidelines for this project'
 [`funding`]:
   ./.github/FUNDING.yml
   'How to financially support maintenance/development of @OpenINF projects on GitHub using GitHub Sponsors'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ a file named `LICENSE` in the root directory of the repository.
 
 ## Project documentation
 
-The `README.md` in the root of the repository should contain or link to project
+The [`README.md`] in the root of the repository should contain or link to project
 documentation. If you cannot find the documentation you’re looking for, please
 file a GitHub issue with details of what you’d like to see documented.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,8 +134,8 @@ Please see the [`SECURITY.md`] file.
 
 [Developer Certificate of Origin Legal Text](https://developercertificate.org/)
 
-[**@openinf**]: https://github.com/OpenINF
-[**@openinf/.github**]: https://github.com/OpenINF/.github
+[**@OpenINF**]: https://github.com/OpenINF
+[**@OpenINF/.github**]: https://github.com/OpenINF/.github
 [`authors`]:
   https://github.com/openinf/.github/blob/HEAD/AUTHORS
   'List of people who have contributed code to this project'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ Please see the [`SECURITY.md`][] file.
 [`SECURITY.md`]:
   ./SECURITY.md
   'Instructions on how to report security vulnerabilities for this project'
-[`support`]: ./SUPPORT.md 'Where to get help on this project'
+[`SUPPORT.md`]: ./SUPPORT.md 'Where to get help on this project'
 [`vision`]: ./VISION.md 'What the goal(s) and/or scope are of this project'
 [contrib-license]:
   https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,7 @@ By making a contribution to this project, I certify that:
 ## Attribution
 
 [Developer Certificate of Origin Legal Text](https://developercertificate.org/)
+
 <!-- prettier-ignore-start -->
 <!-- PRESERVE LINK DEFINITION LABEL CASE - START -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project uses the following tools to organize discussion.
 ## Issue Tracker
 
 If you’ve found a bug, would like to request a new feature or make a proposal,
-file an [issue][]!
+file a [GitHub issue]!
 
 ### Resolving open issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ We track ongoing endeavors via the GitHub issues associated with each
 repository, and that’s where you can find tasks to undertake. First, check the
 labels on the issue you’re interested in.
 
-- Issues labeled https://github.com/openinf/.github/labels/help%20wanted or
+- Issues labeled https://github.com/OpenINF/.github/labels/help%20wanted or
   https://github.com/OpenINF/.github/labels/good%20first%20issue have been
   identified as desirable for community contribution. Feel free to work on
   <abbr title="Good First Issues">GFIs</abbr> even if not your first issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Once you have identified an issue you would like to work on, follow these steps:
     submit your PR.
 4.  Wait for code review and address any issues raised as soon as you can.
 
-Even if you are not done with the issue, create a [draft pull request][] and
+Even if you are not done with the issue, create a [draft pull request] and
 push your code [early and often][]. If we haven’t heard from you in over a week
 and someone else expresses interest in that issue, we may approve the new
 person’s work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,9 +134,6 @@ Please see the [`SECURITY.md`] file.
 
 [Developer Certificate of Origin Legal Text](https://developercertificate.org/)
 
-<!-- prettier-ignore-start -->
-<!-- PRESERVE LINK DEFINITION LABEL CASE - START -->
-
 [**@openinf**]: https://github.com/openinf
 [**@openinf/.github**]: https://github.com/openinf/.github
 [`AUTHORS`]:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,9 @@ a file named `LICENSE` in the root directory of the repository.
 
 ## Project documentation
 
-The [`README.md`] in the root of the repository should contain or link to project
-documentation. If you cannot find the documentation you’re looking for, please
-file a GitHub issue with details of what you’d like to see documented.
+The [`README.md`] in the root of the repository should contain or link to
+project documentation. If you cannot find the documentation you’re looking for,
+please file a GitHub issue with details of what you’d like to see documented.
 
 ## Questions or thoughts?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ labels on the issue you’re interested in.
   - List of [all incomplete pull requests labeled _help wanted_][pr-help]
 - If the issue does not have either of those labels, it may still be open for
   contribution.
-- Issues labeled https://github.com/openinf/.github/labels/wip are a _work in
+- Issues labeled https://github.com/OpenINF/.github/labels/wip are a _work in
   progress_ and generally not available, but may be available if there has been
   no activity on the issue or related PR for over a week.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ Please see the [`SECURITY.md`][] file.
 
 [**@OpenINF**]: https://github.com/OpenINF
 [**@OpenINF/.github**]: https://github.com/OpenINF/.github
-[`authors`]:
+[`AUTHORS`]:
   https://github.com/OpenINF/.github/blob/HEAD/AUTHORS
   'List of people who have contributed code to this project'
 [`CODE_OF_CONDUCT.md`]:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ details and the rationale for the proposed change.
 
 ## Pull Requests
 
-If you’d like to propose and collaborate on changes, open a [pull request]!
+If you’d like to propose and collaborate on changes, open a [pull request][]!
 
 Here are a few things you can do that will increase the likelihood of having
 your pull request merged:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,3 @@ Please see the [`SECURITY.md`] file.
   https://github.com/search?q=org%3Aopeninf+is%3Apr+is%3Aopen+label%3A%22help+wanted%22
 [pull request]:
   https://help.github.com/en/desktop/contributing-to-projects/creating-a-pull-request
-
-<!-- PRESERVE LINK DEFINITION LABEL CASE - END -->
-<!-- prettier-ignore-end -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ on Twitter.
 ## Code of Conduct
 
 By participating in this project, you are expected to uphold our Code of
-Conduct. Please see the [`CODE_OF_CONDUCT.md`] file for expected behavior.
+Conduct. Please see the [`CODE_OF_CONDUCT.md`][] file for expected behavior.
 
 ## Developer’s Certificate of Origin 1.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ repository, and that’s where you can find tasks to undertake. First, check the
 labels on the issue you’re interested in.
 
 - Issues labeled https://github.com/openinf/.github/labels/help%20wanted or
-  https://github.com/openinf/.github/labels/good%20first%20issue have been
+  https://github.com/OpenINF/.github/labels/good%20first%20issue have been
   identified as desirable for community contribution. Feel free to work on
   <abbr title="Good First Issues">GFIs</abbr> even if not your first issue.
   - List of [all issues labeled _good first issue_][i-gfi]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ Please see the [`SECURITY.md`][] file.
 [`CODE_OF_CONDUCT.md`]:
   ./CODE_OF_CONDUCT.md
   'Standards for how to engage with the project community'
-[`contributing`]: ./CONTRIBUTING.md 'Contribution guidelines for this project'
+[`CONTRIBUTING`]: ./CONTRIBUTING.md 'Contribution guidelines for this project'
 [`funding`]:
   ./.github/FUNDING.yml
   'How to financially support maintenance/development of @OpenINF projects on GitHub using GitHub Sponsors'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project uses the following tools to organize discussion.
 ## Issue Tracker
 
 If you’ve found a bug, would like to request a new feature or make a proposal,
-file a [GitHub issue]!
+file a [GitHub issue][]!
 
 ### Resolving Open Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ push your code [early and often][]. If we haven’t heard from you in over a wee
 and someone else expresses interest in that issue, we may approve the new
 person’s work.
 
-### Opening a new issue
+### Opening a New Issue
 
 If you want to work on something that there is no GitHub issue for, then propose
 the change by opening a new GitHub issue associated with the respective

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ a file named `LICENSE` in the root directory of the repository.
 
 ## Project Documentation
 
-The [`README.md`] in the root of the repository should contain or link to
+The [`README.md`][] in the root of the repository should contain or link to
 project documentation. If you cannot find the documentation you’re looking for,
 please file a GitHub issue with details of what you’d like to see documented.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,10 @@ By making a contribution to this project, I certify that:
   redistributed consistent with this project or the open source license(s)
   involved.
 
+## Reporting Security Issues
+
+Please see [SECURITY.md](./SECURITY.md).
+
 ## Attribution
 
 [Developer Certificate of Origin Legal Text](https://developercertificate.org/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,9 +130,43 @@ By making a contribution to this project, I certify that:
 
 [Developer Certificate of Origin Legal Text](https://developercertificate.org/)
 
-[code_of_conduct]: ./CODE_OF_CONDUCT.md
+
+<!-- prettier-ignore-start -->
+<!-- PRESERVE LINK DEFINITION LABEL CASE - START -->
+
+[**@openinf**]: https://github.com/openinf
+[**@openinf/.github**]: https://github.com/openinf/.github
+[`AUTHORS`]:
+  https://github.com/openinf/.github/blob/HEAD/AUTHORS
+  'List of people who have contributed code to this project'
+[`CODE_OF_CONDUCT`]:
+  ./CODE_OF_CONDUCT.md
+  'Standards for how to engage with the project community'
+[`CONTRIBUTING`]:
+  ./CONTRIBUTING.md
+  'Contribution guidelines for this project'
+[`FUNDING`]:
+  ./.github/FUNDING.yml
+  'How to financially support maintenance/development of @openinf projects on GitHub using GitHub Sponsors'
+[`LICENSE`]:
+  ./LICENSE
+  'The open source software license(s) associated with this project'
+[`README`]:
+  ./README.md
+  'The landing/home page of this project'
+[`SECURITY`]:
+  ./SECURITY.md
+  'Instructions on how to report security vulnerabilities for this project'
+[`SUPPORT`]:
+  ./SUPPORT.md
+  'Where to get help on this project'
+[`VISION`]:
+  ./VISION.md
+  'What the goal(s) and/or scope are of this project'
+
 [contrib-license]:
   https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
+[dco]: https://developercertificate.org
 [draft pull request]:
   https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
 [early and often]: https://www.worklytics.co/blog/commit-early-push-often/
@@ -143,8 +177,6 @@ By making a contribution to this project, I certify that:
 [i-help]:
   https://github.com/search?q=org%3Aopeninf+is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
 
-<!-- [irc-channel]: https://webchat.freenode.net/#openinf -->
-
 [twitter-account]: https://twitter.com/openinf
 [issue]:
   http://help.github.com/en/github/managing-your-work-on-github/creating-an-issue
@@ -152,3 +184,6 @@ By making a contribution to this project, I certify that:
   https://github.com/search?q=org%3Aopeninf+is%3Apr+is%3Aopen+label%3A%22help+wanted%22
 [pull request]:
   https://help.github.com/en/desktop/contributing-to-projects/creating-a-pull-request
+  
+<!-- PRESERVE LINK DEFINITION LABEL CASE - END -->
+<!-- prettier-ignore-end -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,6 @@ By making a contribution to this project, I certify that:
 ## Attribution
 
 [Developer Certificate of Origin Legal Text](https://developercertificate.org/)
-
 <!-- prettier-ignore-start -->
 <!-- PRESERVE LINK DEFINITION LABEL CASE - START -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ Please see the [`SECURITY.md`][] file.
 [`LICENSE`]:
   ./LICENSE
   'The open source software license(s) associated with this project'
-[`readme`]: ./README.md 'The landing/home page of this project'
+[`README.md`]: ./README.md 'The landing/home page of this project'
 [`security`]:
   ./SECURITY.md
   'Instructions on how to report security vulnerabilities for this project'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,8 +134,8 @@ Please see the [`SECURITY.md`] file.
 
 [Developer Certificate of Origin Legal Text](https://developercertificate.org/)
 
-[**@openinf**]: https://github.com/openinf
-[**@openinf/.github**]: https://github.com/openinf/.github
+[**@OpenINF**]: https://github.com/OpenINF
+[**@OpenINF/.github**]: https://github.com/OpenINF/.github
 [`authors`]:
   https://github.com/openinf/.github/blob/HEAD/AUTHORS
   'List of people who have contributed code to this project'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Once you have identified an issue you would like to work on, follow these steps:
     submit your PR.
 4.  Wait for code review and address any issues raised as soon as you can.
 
-Even if you are not done with the issue, create a [draft pull request] and
+Even if you are not done with the issue, create a [draft pull request][] and
 push your code [early and often][]. If we haven’t heard from you in over a week
 and someone else expresses interest in that issue, we may approve the new
 person’s work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This project uses the following tools to organize discussion.
 If you’ve found a bug, would like to request a new feature or make a proposal,
 file a [GitHub issue]!
 
-### Resolving open issues
+### Resolving Open Issues
 
 We track ongoing endeavors via the GitHub issues associated with each
 repository, and that’s where you can find tasks to undertake. First, check the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,34 +136,25 @@ Please see the [`SECURITY.md`] file.
 
 [**@openinf**]: https://github.com/openinf
 [**@openinf/.github**]: https://github.com/openinf/.github
-[`AUTHORS`]:
+[`authors`]:
   https://github.com/openinf/.github/blob/HEAD/AUTHORS
   'List of people who have contributed code to this project'
-[`CODE_OF_CONDUCT`]:
+[`code_of_conduct`]:
   ./CODE_OF_CONDUCT.md
   'Standards for how to engage with the project community'
-[`CONTRIBUTING`]:
-  ./CONTRIBUTING.md
-  'Contribution guidelines for this project'
-[`FUNDING`]:
+[`contributing`]: ./CONTRIBUTING.md 'Contribution guidelines for this project'
+[`funding`]:
   ./.github/FUNDING.yml
   'How to financially support maintenance/development of @OpenINF projects on GitHub using GitHub Sponsors'
-[`LICENSE`]:
+[`license`]:
   ./LICENSE
   'The open source software license(s) associated with this project'
-[`README`]:
-  ./README.md
-  'The landing/home page of this project'
-[`SECURITY`]:
+[`readme`]: ./README.md 'The landing/home page of this project'
+[`security`]:
   ./SECURITY.md
   'Instructions on how to report security vulnerabilities for this project'
-[`SUPPORT`]:
-  ./SUPPORT.md
-  'Where to get help on this project'
-[`VISION`]:
-  ./VISION.md
-  'What the goal(s) and/or scope are of this project'
-
+[`support`]: ./SUPPORT.md 'Where to get help on this project'
+[`vision`]: ./VISION.md 'What the goal(s) and/or scope are of this project'
 [contrib-license]:
   https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
 [dco]: https://developercertificate.org
@@ -176,7 +167,6 @@ Please see the [`SECURITY.md`] file.
   https://github.com/search?q=org%3Aopeninf+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [i-help]:
   https://github.com/search?q=org%3Aopeninf+is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
-
 [twitter-account]: https://twitter.com/openinf
 [issue]:
   http://help.github.com/en/github/managing-your-work-on-github/creating-an-issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ This project uses the following tools to organize discussion.
 - **Synchronous chat channel:** For casual conversation, collaboration, quick
   exchanges, and questions.
 
-## Issue tracker
+## Issue Tracker
 
 If you’ve found a bug, would like to request a new feature or make a proposal,
 file an [issue][]!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Once you have identified an issue you would like to work on, follow these steps:
 1.  Comment on it and say you would like to work on that issue.
 2.  Wait for someone to confirm that you may work on the issue before writing
     any code. The person who confirms will add a
-    https://github.com/openinf/.github/labels/wip label to the issue to indicate
+    https://github.com/OpenINF/.github/labels/wip label to the issue to indicate
     that the issue has been assigned.
 3.  Once the issue has been labeled as a _work in progress_, write your code and
     submit your PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ file a GitHub issue with details of what you’d like to see documented.
 ## Questions or thoughts?
 
 Support requests (e.g., asking questions) or feedback (e.g., constructive
-criticism) may be directed to the [`@openinf`][twitter-account] support account
+criticism) may be directed to the [`@OpenINF`][twitter-account] support account
 on Twitter.
 
 ## Additional resources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,7 @@ By making a contribution to this project, I certify that:
 
 [Developer Certificate of Origin Legal Text](https://developercertificate.org/)
 
+
 <!-- prettier-ignore-start -->
 <!-- PRESERVE LINK DEFINITION LABEL CASE - START -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ By making a contribution to this project, I certify that:
 
 ## Reporting Security Issues
 
-Please see the [`SECURITY.md`] file.
+Please see the [`SECURITY.md`][] file.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ By making a contribution to this project, I certify that:
 
 ## Reporting Security Issues
 
-Please see [SECURITY.md](./SECURITY.md).
+Please see the [`SECURITY.md`] file.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,24 +26,26 @@ We track ongoing endeavors via the GitHub issues associated with each
 repository, and that’s where you can find tasks to undertake. First, check the
 labels on the issue you’re interested in.
 
-- Issues labeled https://github.com/openinf/.github/labels/help%20wanted or https://github.com/openinf/.github/labels/good%20first%20issue have been identified as
-  desirable for community contribution. Feel free to work on <abbr title="Good First Issues">GFIs</abbr> even if not
-  your first issue.
+- Issues labeled https://github.com/openinf/.github/labels/help%20wanted or
+  https://github.com/openinf/.github/labels/good%20first%20issue have been
+  identified as desirable for community contribution. Feel free to work on
+  <abbr title="Good First Issues">GFIs</abbr> even if not your first issue.
   - List of [all issues labeled _good first issue_][i-gfi]
   - List of [all issues labeled _help wanted_][i-help]
   - List of [all incomplete pull requests labeled _help wanted_][pr-help]
 - If the issue does not have either of those labels, it may still be open for
   contribution.
-- Issues labeled https://github.com/openinf/.github/labels/wip are a _work in progress_
-  and generally not available, but may be available if there has been no activity on the
-  issue or related PR for over a week.
+- Issues labeled https://github.com/openinf/.github/labels/wip are a _work in
+  progress_ and generally not available, but may be available if there has been
+  no activity on the issue or related PR for over a week.
 
 Once you have identified an issue you would like to work on, follow these steps:
 
 1.  Comment on it and say you would like to work on that issue.
 2.  Wait for someone to confirm that you may work on the issue before writing
-    any code. The person who confirms will add a https://github.com/openinf/.github/labels/wip label to the
-    issue to indicate that the issue has been assigned.
+    any code. The person who confirms will add a
+    https://github.com/openinf/.github/labels/wip label to the issue to indicate
+    that the issue has been assigned.
 3.  Once the issue has been labeled as a _work in progress_, write your code and
     submit your PR.
 4.  Wait for code review and address any issues raised as soon as you can.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,6 @@ By making a contribution to this project, I certify that:
 
 [Developer Certificate of Origin Legal Text](https://developercertificate.org/)
 
-
 <!-- prettier-ignore-start -->
 <!-- PRESERVE LINK DEFINITION LABEL CASE - START -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,6 @@ By making a contribution to this project, I certify that:
   https://github.com/search?q=org%3Aopeninf+is%3Apr+is%3Aopen+label%3A%22help+wanted%22
 [pull request]:
   https://help.github.com/en/desktop/contributing-to-projects/creating-a-pull-request
-  
+
 <!-- PRESERVE LINK DEFINITION LABEL CASE - END -->
 <!-- prettier-ignore-end -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,8 @@
-<!-- https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/setting-guidelines-for-repository-contributors -->
+<!--
+
+https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/setting-guidelines-for-repository-contributors
+
+-->
 
 # Contributor Roles and Responsibilities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Please see the [`SECURITY.md`][] file.
   ./SECURITY.md
   'Instructions on how to report security vulnerabilities for this project'
 [`SUPPORT.md`]: ./SUPPORT.md 'Where to get help on this project'
-[`vision`]: ./VISION.md 'What the goal(s) and/or scope are of this project'
+[`VISION.md`]: ./VISION.md 'What the goal(s) and/or scope are of this project'
 [contrib-license]:
   https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
 [dco]: https://developercertificate.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,152 @@
+<!-- https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/setting-guidelines-for-repository-contributors -->
+
+# Contributor Roles and Responsibilities
+
+Want to contribute? Great! First, read this document, which is a set of
+guidelines to help you contribute to this project.
+
+Whether you’re finding bugs, adding new capabilities, fixing anything broken, or
+improving documentation, get started by submitting an issue or pull request.
+
+This project uses the following tools to organize discussion.
+
+- **Issue tracker:** For discussing issues related to the project.
+- **Pull requests:** For discussing and reviewing changes that are in progress.
+- **Synchronous chat channel:** For casual conversation, collaboration, quick
+  exchanges, and questions.
+
+## Issue tracker
+
+If you’ve found a bug, would like to request a new feature or make a proposal,
+file an [issue][]!
+
+### Resolving open issues
+
+We track ongoing endeavors via the GitHub issues associated with each
+repository, and that’s where you can find tasks to undertake. First, check the
+labels on the issue you’re interested in.
+
+- Issues labeled https://github.com/openinf/.github/labels/help%20wanted or https://github.com/openinf/.github/labels/good%20first%20issue have been identified as
+  desirable for community contribution. Feel free to work on <abbr title="Good First Issues">GFIs</abbr> even if not
+  your first issue.
+  - List of [all issues labeled _good first issue_][i-gfi]
+  - List of [all issues labeled _help wanted_][i-help]
+  - List of [all incomplete pull requests labeled _help wanted_][pr-help]
+- If the issue does not have either of those labels, it may still be open for
+  contribution.
+- Issues labeled https://github.com/openinf/.github/labels/wip are a _work in progress_
+  and generally not available, but may be available if there has been no activity on the
+  issue or related PR for over a week.
+
+Once you have identified an issue you would like to work on, follow these steps:
+
+1.  Comment on it and say you would like to work on that issue.
+2.  Wait for someone to confirm that you may work on the issue before writing
+    any code. The person who confirms will add a https://github.com/openinf/.github/labels/wip label to the
+    issue to indicate that the issue has been assigned.
+3.  Once the issue has been labeled as a _work in progress_, write your code and
+    submit your PR.
+4.  Wait for code review and address any issues raised as soon as you can.
+
+Even if you are not done with the issue, create a [draft pull request][] and
+push your code [early and often][]. If we haven’t heard from you in over a week
+and someone else expresses interest in that issue, we may approve the new
+person’s work.
+
+### Opening a new issue
+
+If you want to work on something that there is no GitHub issue for, then propose
+the change by opening a new GitHub issue associated with the respective
+repository and propose your change there. Be sure to include implementation
+details and the rationale for the proposed change.
+
+## Pull requests
+
+If you’d like to propose and collaborate on changes, open a [pull request][]!
+
+Here are a few things you can do that will increase the likelihood of having
+your pull request merged:
+
+- Follow standards for style and code quality.
+- Write tests when applicable.
+- Keep your change as focused as possible. If there are multiple changes you
+  would like to make that are not dependent upon each other, consider submitting
+  them as separate pull requests.
+- Write a [good commit message][].
+
+Contributions to this project are [released][contrib-license] to the public
+under the project’s open source license. The license for a project is located in
+a file named `LICENSE` in the root directory of the repository.
+
+## Project documentation
+
+The `README.md` in the root of the repository should contain or link to project
+documentation. If you cannot find the documentation you’re looking for, please
+file a GitHub issue with details of what you’d like to see documented.
+
+## Questions or thoughts?
+
+Support requests (e.g., asking questions) or feedback (e.g., constructive
+criticism) may be directed to the [`@openinf`][twitter-account] support account
+on Twitter.
+
+## Additional resources
+
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
+- [GitHub Help](https://help.github.com)
+
+## Code of Conduct
+
+By participating in this project, you are expected to uphold our [Code of
+Conduct][code_of_conduct].
+
+## Developer’s Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+- (a) The contribution was created in whole or in part by me and I have the
+  right to submit it under the open source license indicated in the file; or
+
+- (b) The contribution is based upon previous work that, to the best of my
+  knowledge, is covered under an appropriate open source license and I have the
+  right under that license to submit that work with modifications, whether
+  created in whole or in part by me, under the same open source license (unless
+  I am permitted to submit under a different license), as indicated in the file;
+  or
+
+- (c) The contribution was provided directly to me by some other person who
+  certified (a), (b) or (c) and I have not modified it.
+
+- (d) I understand and agree that this project and the contribution are public
+  and that a record of the contribution (including all personal information I
+  submit with it, including my sign-off) is maintained indefinitely and may be
+  redistributed consistent with this project or the open source license(s)
+  involved.
+
+## Attribution
+
+[Developer Certificate of Origin Legal Text](https://developercertificate.org/)
+
+[code_of_conduct]: ./CODE_OF_CONDUCT.md
+[contrib-license]:
+  https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
+[draft pull request]:
+  https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
+[early and often]: https://www.worklytics.co/blog/commit-early-push-often/
+[good commit message]:
+  http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[i-gfi]:
+  https://github.com/search?q=org%3Aopeninf+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[i-help]:
+  https://github.com/search?q=org%3Aopeninf+is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
+
+<!-- [irc-channel]: https://webchat.freenode.net/#openinf -->
+
+[twitter-account]: https://twitter.com/openinf
+[issue]:
+  http://help.github.com/en/github/managing-your-work-on-github/creating-an-issue
+[pr-help]:
+  https://github.com/search?q=org%3Aopeninf+is%3Apr+is%3Aopen+label%3A%22help+wanted%22
+[pull request]:
+  https://help.github.com/en/desktop/contributing-to-projects/creating-a-pull-request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ the change by opening a new GitHub issue associated with the respective
 repository and propose your change there. Be sure to include implementation
 details and the rationale for the proposed change.
 
-## Pull requests
+## Pull Requests
 
 If you’d like to propose and collaborate on changes, open a [pull request][]!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ Please see the [`SECURITY.md`] file.
   'Contribution guidelines for this project'
 [`FUNDING`]:
   ./.github/FUNDING.yml
-  'How to financially support maintenance/development of @openinf projects on GitHub using GitHub Sponsors'
+  'How to financially support maintenance/development of @OpenINF projects on GitHub using GitHub Sponsors'
 [`LICENSE`]:
   ./LICENSE
   'The open source software license(s) associated with this project'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,8 +134,8 @@ Please see the [`SECURITY.md`] file.
 
 [Developer Certificate of Origin Legal Text](https://developercertificate.org/)
 
-[**@OpenINF**]: https://github.com/OpenINF
-[**@OpenINF/.github**]: https://github.com/OpenINF/.github
+[**@openinf**]: https://github.com/OpenINF
+[**@openinf/.github**]: https://github.com/OpenINF/.github
 [`authors`]:
   https://github.com/openinf/.github/blob/HEAD/AUTHORS
   'List of people who have contributed code to this project'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ Please see the [`SECURITY.md`] file.
   https://github.com/search?q=org%3Aopeninf+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [i-help]:
   https://github.com/search?q=org%3Aopeninf+is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
-[twitter-account]: https://twitter.com/openinf
+[twitter-account]: https://twitter.com/OpenINF
 [GitHub issue]:
   http://help.github.com/en/github/managing-your-work-on-github/creating-an-issue
 [pr-help]:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ Please see the [`SECURITY.md`] file.
 [**@OpenINF**]: https://github.com/OpenINF
 [**@OpenINF/.github**]: https://github.com/OpenINF/.github
 [`authors`]:
-  https://github.com/openinf/.github/blob/HEAD/AUTHORS
+  https://github.com/OpenINF/.github/blob/HEAD/AUTHORS
   'List of people who have contributed code to this project'
 [`CODE_OF_CONDUCT.md`]:
   ./CODE_OF_CONDUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ Please see the [`SECURITY.md`] file.
 [i-help]:
   https://github.com/search?q=org%3Aopeninf+is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
 [twitter-account]: https://twitter.com/openinf
-[issue]:
+[GitHub issue]:
   http://help.github.com/en/github/managing-your-work-on-github/creating-an-issue
 [pr-help]:
   https://github.com/search?q=org%3Aopeninf+is%3Apr+is%3Aopen+label%3A%22help+wanted%22


### PR DESCRIPTION
I am opening this as a draft PR to ensure that the part about commits signing, commit message format, and PR title is covered here as well once we get guidelines for that drafted (conventional commits, slightly customized).

Signed-off-by: Derek Lewis <DerekNonGeneric@inf.is>

/cc @yuvilio @shellscape