### PR TITLE
build(pjson): create dep manifest via `npm init`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository": "openinf/.github",
+  "repository": "https://github.com/openinf/.github",
   "keywords": [],
   "author": "The OpenINF Authors",
   "license": "MIT",
-  "bugs": "https://github.com/openinf/.github/issues",
-  "homepage": "https://github.com/openinf/.github#readme",
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -2,18 +2,18 @@
   "name": "@openinf/.github",
   "version": "0.0.0-development",
   "description": "",
+  "keywords": [],
+  "repository": "https://github.com/openinf/.github",
+  "license": "MIT",
+  "author": "The OpenINF Authors",
   "main": "",
   "directories": {
-    "doc": "doc",
     "lib": "lib",
+    "doc": "doc",
     "test": "test"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository": "https://github.com/openinf/.github",
-  "keywords": [],
-  "author": "The OpenINF Authors",
-  "license": "MIT",
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@openinf/.github",
+  "version": "0.0.0-development",
+  "description": "",
+  "main": "",
+  "directories": {
+    "doc": "doc",
+    "lib": "lib",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": "openinf/.github",
+  "keywords": [],
+  "author": "The OpenINF Authors",
+  "license": "MIT",
+  "bugs": "https://github.com/openinf/.github/issues",
+  "homepage": "https://github.com/openinf/.github#readme",
+  "devDependencies": {}
+}


### PR DESCRIPTION
This results from `npm init` and slight manual adjustment &mdash; I think getting this merged rather quickly would be smart. If anyone has any thoughts on it, feedback would be appreciated. Not a problem that the commit is unverified (unsigned); that is just because I need to rotate the signing key (more on that later). This is intended to be rather minimal w/ just the bare minimum&hellip;

> **A package.json file must contain "name" and "version" fields.**
>
> The "name" field contains your package's name, and must be lowercase and one word, and may contain > hyphens and underscores.
>
> The "version" field must be in the form x.x.x and follow the [semantic versioning guidelines](https://docs.npmjs.com/about-semantic-versioning).
>
> &mdash; https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields

> - The names of scoped packages can begin with a dot or an underscore. This is not permitted without a scope.
> 
> - New packages must not have uppercase letters in the name.
>
> &mdash; https://docs.npmjs.com/cli/v8/configuring-npm/package-json#name

This should help explain some of my decisions (cannot be `@OpenINF` for the npm package name scope&hellip;).

> The CommonJS [Packages](http://wiki.commonjs.org/wiki/Packages/1.0) spec details a few ways that you can indicate the structure of your package using a directories object. If you look at [npm's package.json](https://registry.npmjs.org/npm/latest), you'll see that it has directories for doc, lib, and man.
>
> In the future, this information may be used in other creative ways.
>
> &mdash; https://docs.npmjs.com/cli/v8/configuring-npm/package-json#directories

/cc @septs

Signed-off-by: Derek Lewis <DerekNonGeneric@inf.is>