### PR TITLE
new(automation): configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,50 @@
+# $schema: https://json.schemastore.org/dependabot-2.0.json
 version: 2
 updates:
-
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      timezone: Europe/Belgrade # https://time.is/Serbia#time_difference
+      time: 13:00
     open-pull-requests-limit: 10
+    reviewers:
+      - emmitrovic
+      - openinf/wg-a-team
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
-     open-pull-requests-limit: 10
+      interval: weekly
+      day: tuesday
+      timezone: Europe/Belgrade # https://time.is/Serbia#time_difference
+      time: 13:00
+    open-pull-requests-limit: 10
+    reviewers:
+      - emmitrovic
+      - openinf/wg-a-team
 
-  - package-ecosystem: docker
+  - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      timezone: Europe/Belgrade # https://time.is/Serbia#time_difference
+      time: 13:00
     open-pull-requests-limit: 10
+    reviewers:
+      - emmitrovic
+      - openinf/wg-a-team
 
   - package-ecosystem: docker
     directory: /.devcontainer
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      timezone: Europe/Belgrade # https://time.is/Serbia#time_difference
+      time: 13:00
     open-pull-requests-limit: 10
+    reviewers:
+      - emmitrovic
+      - openinf/wg-a-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: weekly
       day: tuesday
       timezone: Europe/Belgrade # https://time.is/Serbia#time_difference
-      time: 13:00
+      time: '13:00'
     open-pull-requests-limit: 10
     reviewers:
       - emmitrovic
@@ -19,7 +19,7 @@ updates:
       interval: weekly
       day: tuesday
       timezone: Europe/Belgrade # https://time.is/Serbia#time_difference
-      time: 13:00
+      time: '13:00'
     open-pull-requests-limit: 10
     reviewers:
       - emmitrovic
@@ -31,7 +31,7 @@ updates:
       interval: weekly
       day: tuesday
       timezone: Europe/Belgrade # https://time.is/Serbia#time_difference
-      time: 13:00
+      time: '13:00'
     open-pull-requests-limit: 10
     reviewers:
       - emmitrovic
@@ -43,7 +43,7 @@ updates:
       interval: weekly
       day: tuesday
       timezone: Europe/Belgrade # https://time.is/Serbia#time_difference
-      time: 13:00
+      time: '13:00'
     open-pull-requests-limit: 10
     reviewers:
       - emmitrovic

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+     open-pull-requests-limit: 10
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: docker
+    directory: /.devcontainer
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
I left the [`schedule.time`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletime) unspecified since i am not sure what would be ideal for others, but these prs do not bother me, so if anyone have a preference, we can set [`schedule.timezone`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletimezone) if that would be preferable.

```yml
    schedule:
      interval: "daily"
      time: "09:00"
      # Use Japan Standard Time (UTC +09:00)
      timezone: "Asia/Tokyo"
```

Refs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file

/cc @smorimoto as i just thought about your struggle over in the tc39 site repo &mdash; maybe it would be smart to set this up over there too?

Signed-off-by: Derek Lewis <DerekNonGeneric@inf.is>