### PR TITLE
feat: add linguist & handle obscure languages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,9 +2,8 @@
 
 FROM dereknongeneric/fish
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+# Needed by Linguist
+# See: https://github.com/github/linguist/blob/HEAD/README.md#dependencies
+# TODO(@DerekNonGeneric): add these to shared devcontainer image and remove this
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends sudo apt-get install build-essential cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev ruby-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,50 +11,29 @@
 
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
-    // https://marketplace.visualstudio.com/items?itemName=aaron-bond.better-comments
     "aaron-bond.better-comments",
-    // https://marketplace.visualstudio.com/items?itemName=christian-kohler.npm-intellisense
     "christian-kohler.npm-intellisense",
-    // https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense
     "christian-kohler.path-intellisense",
-    // https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint
     "davidanson.vscode-markdownlint",
-    // https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
     "dbaeumer.vscode-eslint",
-    // https://marketplace.visualstudio.com/items?itemName=drewbourne.vscode-remark-lint
     "drewbourne.vscode-remark-lint",
-    // https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens
     "eamodio.gitlens",
-    // https://marketplace.visualstudio.com/items?itemName=editorconfig.editorconfig
     "editorconfig.editorconfig",
-    // https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
     "esbenp.prettier-vscode",
-    // https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree
     "Gruntfuggly.todo-tree",
-    // https://marketplace.visualstudio.com/items?itemName=HookyQR.beautify
     "hookyqr.beautify",
-    // https://marketplace.visualstudio.com/items?itemName=ionutvmi.path-autocomplete
     "ionutvmi.path-autocomplete",
-    // https://marketplace.visualstudio.com/items?itemName=KnisterPeter.vscode-commitizen
     "knisterpeter.vscode-commitizen",
-    // https://marketplace.visualstudio.com/items?itemName=lunaryorn.fish-ide
     "lunaryorn.fish-ide",
-    // https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
     "mrmlnc.vscode-json5",
-    // https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker
     "ms-azuretools.vscode-docker",
-    // https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
     "redhat.vscode-yaml",
-    // https://marketplace.visualstudio.com/items?itemName=sissel.shopify-liquid
     "sissel.shopify-liquid",
-    // https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker
     "streetsidesoftware.code-spell-checker",
-    // https://marketplace.visualstudio.com/items?itemName=travisthetechie.write-good-linter
     "travisthetechie.write-good-linter",
-    // https://marketplace.visualstudio.com/items?itemName=travisthetechie.skyapps.fish-vscode
     "skyapps.fish-vscode",
-    // https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
-    "yzhang.markdown-all-in-one"
+    "yzhang.markdown-all-in-one",
+    "tamasfe.even-better-toml"
   ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-*                       text=auto
+*                       text=auto linguist-detectable
 .*.jsonc                diff=jsonc linguist-language=jsonc
 .*.json5                diff=json5 linguist-language=json5
 .devcontainer/*.json    diff=jsonc linguist-language=jsonc
@@ -9,3 +9,4 @@ doc/**                  linguist-documentation
 lib/**                  linguist-generated=true
 OWNERS                  diff=json5 linguist-language=json5
 tsconfig.json           diff=jsonc linguist-language=jsonc
+tsconfig.*.json         diff=jsonc linguist-language=jsonc

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -35,6 +35,12 @@
       }
     },
     {
+      "files": "**/**.t?(o)ml",
+      "options": {
+        "parser": "toml"
+      }
+    },
+    {
       "files": "**/**.y?(a)ml",
       "options": {
         "parser": "yaml"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,27 @@
 {
   "recommendations": [
+    "aaron-bond.better-comments",
+    "christian-kohler.npm-intellisense",
+    "christian-kohler.path-intellisense",
+    "davidanson.vscode-markdownlint",
     "dbaeumer.vscode-eslint",
+    "drewbourne.vscode-remark-lint",
+    "eamodio.gitlens",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
+    "Gruntfuggly.todo-tree",
+    "hookyqr.beautify",
+    "ionutvmi.path-autocomplete",
+    "knisterpeter.vscode-commitizen",
+    "lunaryorn.fish-ide",
     "mrmlnc.vscode-json5",
+    "ms-azuretools.vscode-docker",
     "redhat.vscode-yaml",
-    "bungcip.better-toml",
-    "aaron-bond.better-comments",
-    "DavidAnson.vscode-markdownlint"
+    "sissel.shopify-liquid",
+    "streetsidesoftware.code-spell-checker",
+    "travisthetechie.write-good-linter",
+    "skyapps.fish-vscode",
+    "yzhang.markdown-all-in-one",
+    "tamasfe.even-better-toml"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,7 +48,9 @@
     "tsconfig.*.json": "jsonc",
     "tsconfig.json": "jsonc",
     ".eslintrc.json": "jsonc",
-    ".prettierrc.json5": "json5"
+    ".prettierrc.json": "json5",
+    ".prettierrc.json5": "json5",
+    ".deepsource.toml": "toml"
   },
 
   // JavaScript/TypeScript

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "github-linguist", "~> 7.22"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    cgi (0.3.2)
+    charlock_holmes (0.7.7)
+    github-linguist (7.22.1)
+      cgi
+      charlock_holmes (~> 0.7.7)
+      mini_mime (~> 1.0)
+      rugged (~> 1.0)
+    mini_mime (1.1.2)
+    rugged (1.5.0.1)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  github-linguist (~> 7.22)
+
+BUNDLED WITH
+   2.3.7


### PR DESCRIPTION
This PR adds [the `github-linguist` gem](https://rubygems.org/gems/github-linguist) to the project for better determining what certain obscure or extensionless files are being interpreted as by GitHub to ensure that they are being accounted for. Some notes from the commit message:

First running the following commands may be necessary:

```fish
git config --global --add safe.directory '*'
sudo chown -R (whoami) ../
```

These may need to be added to the devcontainer.

Then, languages will be properly detected e.g, via:

```fish
bundle exec github-linguist --breakdown --json
```

Refs: https://linguist.readthedocs.io
Refs: https://github.com/github/linguist/blob/HEAD/docs/overrides.md

Signed-off-by: Derek Lewis <DerekNonGeneric@inf.is>