### PR TITLE
fix(infra): configure git to always use LF for EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-*                       text=auto linguist-detectable
+*                       text=auto eol=lf linguist-detectable
 .*.jsonc                diff=jsonc linguist-language=jsonc
 .*.json5                diff=json5 linguist-language=json5
 .devcontainer/*.json    diff=jsonc linguist-language=jsonc


### PR DESCRIPTION
Believe it or not, when using Git for Windows shell, the line endings get converted to CRLF, causing prettier warnings to display in the text editor. There is also some very verbose copy from the Git command when committing &mdash; we should be explicit here wrt our preference.

Refs: https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-Settostringvaluelf

Signed-off-by: Derek Lewis <DerekNonGeneric@inf.is>