### PR TITLE
fix(devenv): rm unpublished vscode extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,29 +11,50 @@
 
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
+    // https://marketplace.visualstudio.com/items?itemName=aaron-bond.better-comments
     "aaron-bond.better-comments",
+    // https://marketplace.visualstudio.com/items?itemName=christian-kohler.npm-intellisense
     "christian-kohler.npm-intellisense",
+    // https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense
     "christian-kohler.path-intellisense",
+    // https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint
     "davidanson.vscode-markdownlint",
+    // https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
     "dbaeumer.vscode-eslint",
-    "drewbourne.vscode-remark-lint",
+    // https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens
     "eamodio.gitlens",
+    // https://marketplace.visualstudio.com/items?itemName=editorconfig.editorconfig
     "editorconfig.editorconfig",
+    // https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
     "esbenp.prettier-vscode",
+    // https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree
     "Gruntfuggly.todo-tree",
+    // https://marketplace.visualstudio.com/items?itemName=HookyQR.beautify
     "hookyqr.beautify",
+    // https://marketplace.visualstudio.com/items?itemName=ionutvmi.path-autocomplete
     "ionutvmi.path-autocomplete",
+    // https://marketplace.visualstudio.com/items?itemName=KnisterPeter.vscode-commitizen
     "knisterpeter.vscode-commitizen",
+    // https://marketplace.visualstudio.com/items?itemName=lunaryorn.fish-ide
     "lunaryorn.fish-ide",
+    // https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
     "mrmlnc.vscode-json5",
+    // https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker
     "ms-azuretools.vscode-docker",
+    // https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
     "redhat.vscode-yaml",
+    // https://marketplace.visualstudio.com/items?itemName=sissel.shopify-liquid
     "sissel.shopify-liquid",
+    // https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker
     "streetsidesoftware.code-spell-checker",
+    // https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml
+    "tamasfe.even-better-toml",
+    // https://marketplace.visualstudio.com/items?itemName=travisthetechie.write-good-linter
     "travisthetechie.write-good-linter",
+    // https://marketplace.visualstudio.com/items?itemName=travisthetechie.skyapps.fish-vscode
     "skyapps.fish-vscode",
-    "yzhang.markdown-all-in-one",
-    "tamasfe.even-better-toml"
+    // https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
+    "yzhang.markdown-all-in-one"
   ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,6 @@
     "christian-kohler.path-intellisense",
     "davidanson.vscode-markdownlint",
     "dbaeumer.vscode-eslint",
-    "drewbourne.vscode-remark-lint",
     "eamodio.gitlens",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
@@ -18,10 +17,10 @@
     "ms-azuretools.vscode-docker",
     "redhat.vscode-yaml",
     "sissel.shopify-liquid",
-    "streetsidesoftware.code-spell-checker",
-    "travisthetechie.write-good-linter",
     "skyapps.fish-vscode",
-    "yzhang.markdown-all-in-one",
-    "tamasfe.even-better-toml"
+    "streetsidesoftware.code-spell-checker",
+    "tamasfe.even-better-toml",
+    "travisthetechie.write-good-linter",
+    "yzhang.markdown-all-in-one"
   ]
 }


### PR DESCRIPTION
This PR also re-adds the links to the extensions on the VS Code website to better track when extensions get unpublished like this, which is annoying.

Signed-off-by: Derek Lewis <DerekNonGeneric@inf.is>