### PR TITLE
style(readme): remove prettier-ignore comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,6 @@ to us.
 [^2]:
     <https://docs.npmjs.com/cli/v8/configuring-npm/package-json#default-values>
 
-<!-- prettier-ignore-start -->
-<!-- PRESERVE LINK DEFINITION LABEL CASE - START -->
-
 [give it a star ⭐️]: https://github.com/openinf/.github/stargazers
 
 [**@openinf**]: https://github.com/openinf

--- a/README.md
+++ b/README.md
@@ -175,6 +175,3 @@ to us.
 [npm-badge-url]: https://www.npmjs.com/org/openinf 'View all of OpenINF&apos;s packages published to the npm registry'
 [prettier-badge]: https://img.shields.io/badge/code_style-Prettier-ff69b4.svg?logo=prettier 'Code Style: Prettier'
 [prettier-url]: https://prettier.io/playground 'Code Style: Prettier'
-
-<!-- PRESERVE LINK DEFINITION LABEL CASE - END -->
-<!-- prettier-ignore-end -->


### PR DESCRIPTION
PRESERVE LINK DEFINITION LABEL CASE no longer necessary in latest version of prettier - v2.8.2

Thanks: @DerekNonGeneric

Signed-off-by: Derek Lewis <DerekNonGeneric@inf.is>