### PR TITLE
🐞🔧 ：percent-encode room aliases in matrix.to links

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The [SPDX](https://spdx.dev) license identifier for this project is
   https://img.shields.io/badge/matrix-join%20chat-%2346BC99?logo=matrix
   'Chat on Matrix'
 [matrix-url]:
-  https://matrix.to/#/#openinf-space:matrix.org
+  https://matrix.to/#/%23openinf-space:matrix.org
   "You're invited to talk on Matrix"
 [npm-badge--shields]:
   https://img.shields.io/badge/packages-6-2a2a2a.svg?logo=npm

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -41,7 +41,7 @@ Rules) _and_ our [Code of Conduct][coc].
 [`#support` channel]: https://discord.gg/eZZtnHKN
 [`#general` channel]: https://discord.gg/gUPTCPjd
 [docs-site]: https://open.inf.is
-[matrix-channel]: https://matrix.to/#/#openinf:matrix.org
+[matrix-channel]: https://matrix.to/#/%23openinf:matrix.org
 [support-channel-discord]: https://discord.gg/CYJSYxjN
 [x-twitter-account]: https://twitter.com/OpenINF
 [x-twitter-rules]: https://help.twitter.com/en/rules-and-policies/x-rules


### PR DESCRIPTION
## Pull Request Purpose

This PR contains the following:

- [x] 🐞🔧 bugfixing (🐜/🦟/🐛/🦗/🐝 et al.)
- [ ] 🆕🎏 implementation of new feature(s)
- [ ] ♻️ refactoring(s)
- [x] 📄 documentation modification(s)
- [ ] 🔮 other

### Testing

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

These are two link reference definitions in Markdown documents; there is no code path to cover. Verified instead with the W3C validator (`vnu`) against a page built from each form — see below.

### Breaking Changes

- [ ] yes (_breaking changes will not be merged unless necessary_)
- [x] no

The percent-encoded form resolves to the same rooms.

### Description

`#` is the fragment delimiter, so a second literal `#` inside a URL fragment is invalid per RFC 3986. Both of our matrix.to links carry one:

| file | link |
| --- | --- |
| `SUPPORT.md:44` | `https://matrix.to/#/#openinf:matrix.org` |
| `README.md:252` | `https://matrix.to/#/#openinf-space:matrix.org` |

Running the W3C validator over both forms shows only the raw-`#` one is rejected:

```
error: Bad value “https://matrix.to/#/#openinf:matrix.org” for attribute “href”
on element “a”: Illegal character in fragment. “#” is not allowed.
```

The percent-encoded variant produces no diagnostic, and it is also what [the Matrix spec][spec] asks for — matrix.to URI components "MUST be percent-encoded as per RFC 3986", with `https://matrix.to/#/%23somewhere:example.org` given as the canonical form. (The spec also notes clients should parse the unencoded form leniently, which is why these links still work today despite being invalid.)

**Why this matters beyond tidiness:** `SUPPORT.md` is imported into [openinf.github.io][site] by its `compile.siteifyHealthFiles` task, which renders it to `/docs/dev/faq/support`. That site's `verify.htmlValidForVNU` task now validates every built page rather than only the home page, and this URL is the one remaining error failing it. Since the imported copy is regenerated from this repository, the fix has to land here to hold.

`README.md` has the same defect in a different room alias and is corrected alongside it — happy to drop that hunk if you would rather keep this PR to the single downstream-blocking file.

List of any relevant issue numbers: _none_

[spec]: https://spec.matrix.org/latest/appendices/#matrixto-navigation
[site]: https://github.com/OpenINF/openinf.github.io