### PR TITLE
🐞🔧：make cross-document links absolute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,14 +140,16 @@ Please see the [`SECURITY.md`][] file.
     <https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/setting-guidelines-for-repository-contributors>
 
 [`CODE_OF_CONDUCT.md`]:
-  ./CODE_OF_CONDUCT.md
+  https://github.com/OpenINF/.github/blob/HEAD/CODE_OF_CONDUCT.md
   'Standards for how to engage with the project community'
-[`LICENSE.md`]:
-  ./LICENSE.md
+[`LICENSE`]:
+  https://github.com/OpenINF/.github/tree/HEAD/LICENSE
   'The open source software license(s) associated with this project'
-[`README.md`]: ./README.md 'The landing/home page of this project'
+[`README.md`]:
+  https://github.com/OpenINF/.github/blob/HEAD/README.md
+  'The landing/home page of this project'
 [`SECURITY.md`]:
-  ./SECURITY.md
+  https://github.com/OpenINF/.github/blob/HEAD/SECURITY.md
   'Instructions on how to report security vulnerabilities for this project'
 [contrib-license]:
   https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -36,7 +36,7 @@ Rules) _and_ our [Code of Conduct][coc].
 [^1]:
     <https://help.github.com/en/github/building-a-strong-community/adding-support-resources-to-your-project>
 
-[coc]: ./CODE_OF_CONDUCT.md
+[coc]: https://github.com/OpenINF/.github/blob/HEAD/CODE_OF_CONDUCT.md
 [`#off-topic` channel]: https://discord.gg/ACMjssFV
 [`#support` channel]: https://discord.gg/eZZtnHKN
 [`#general` channel]: https://discord.gg/gUPTCPjd


### PR DESCRIPTION
## Pull Request Purpose

This PR contains the following:

- [x] 🐞🔧 bugfixing (🐜/🦟/🐛/🦗/🐝 et al.)
- [ ] 🆕🎏 implementation of new feature(s)
- [ ] ♻️ refactoring(s)
- [x] 📄 documentation modification(s)
- [ ] 🔮 other

### Testing

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Link reference definitions in Markdown; no code path to cover. Every replacement URL was checked to return `200`.

### Breaking Changes

- [ ] yes (_breaking changes will not be merged unless necessary_)
- [x] no

### Description

These documents get read well outside this repository. GitHub surfaces them as the organization's community health files, and [openinf.github.io][] imports five of them as pages under `/docs`. A repository-relative link only resolves in the first context — rendered at `/docs/dev/faq/support/`, `./CODE_OF_CONDUCT.md` resolves against *that* URL and 404s.

Absolute URLs work in both places. `README.md` already writes its self-references as `https://github.com/OpenINF/.github/blob/HEAD/…`, so this follows the convention already in the repo rather than inventing one.

| file | was | now |
| --- | --- | --- |
| `SUPPORT.md` | `./CODE_OF_CONDUCT.md` | `…/blob/HEAD/CODE_OF_CONDUCT.md` |
| `CONTRIBUTING.md` | `./CODE_OF_CONDUCT.md` | `…/blob/HEAD/CODE_OF_CONDUCT.md` |
| `CONTRIBUTING.md` | `./README.md` | `…/blob/HEAD/README.md` |
| `CONTRIBUTING.md` | `./SECURITY.md` | `…/blob/HEAD/SECURITY.md` |
| `CONTRIBUTING.md` | `./LICENSE.md` | `…/tree/HEAD/LICENSE` |

> [!NOTE]
> That last row is a bug that predates this change and is broken in *every* context, including on GitHub. The prose in `CONTRIBUTING.md` says:
>
> ```markdown
> located within the [`LICENSE`][] folder in the root directory of the repository.
> ```
>
> …but the only definition was `` [`LICENSE.md`] ``. The labels don't match, so the reference never resolved and the definition sat orphaned — and it pointed at `./LICENSE.md`, when `LICENSE` is a *directory* holding `MIT.txt`, `Apache-2.0.txt`, and `BlueOak-1.0.0.txt`. The label now matches the prose and points at that directory. Happy to split this into its own PR if you'd rather keep this one to the relative→absolute change.

#### Why now

openinf.github.io validates its built pages with the W3C validator, and [a fix there][site-pr] stops its import from rewriting your prose to make the links work. Keeping these links portable at the source means that site — and any other consumer — needs no such rewriting.

Follows [#883][].

List of any relevant issue numbers: _none_

[openinf.github.io]: https://github.com/OpenINF/openinf.github.io
[site-pr]: https://github.com/OpenINF/openinf.github.io/pull/1785
[#883]: https://github.com/OpenINF/.github/pull/883