### PR TITLE
🐞🔧：start each health file at heading level one

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-## Code of Conduct[^1]
+# Code of Conduct[^1]
 
 <div align="center">
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributor Roles and Responsibilities[^1]
+# Contributor Roles and Responsibilities[^1]
 
 Want to contribute? Great! First, read this document, which is a set of
 guidelines to help you contribute to this project.
@@ -13,12 +13,12 @@ This project uses the following tools to organize discussion.
 - **Synchronous chat channel:** For casual conversation, collaboration, quick
   exchanges, and questions.
 
-### Issue Tracker
+## Issue Tracker
 
 If you’ve found a bug, would like to request a new feature or make a proposal,
 file a [GitHub issue][]!
 
-#### Resolving Open Issues
+### Resolving Open Issues
 
 We track ongoing endeavors via the GitHub issues associated with each
 repository, and that’s where you can find tasks to undertake. First, check the
@@ -53,14 +53,14 @@ push your code [early and often][]. If we haven’t heard from you in over a wee
 and someone else expresses interest in that issue, we may approve the new
 person’s work.
 
-#### Opening a New Issue
+### Opening a New Issue
 
 If you want to work on something that there is no GitHub issue for, then propose
 the change by opening a new GitHub issue associated with the respective
 repository and propose your change there. Be sure to include implementation
 details and the rationale for the proposed change.
 
-### Pull Requests
+## Pull Requests
 
 If you’d like to propose and collaborate on changes, open a [pull request][]!
 
@@ -80,30 +80,30 @@ located within the [`LICENSE`][] folder in the root directory of the repository.
 
 <!-- TODO: Guidance on SPDX corpus text files using `.txt` extension. -->
 
-### Project Documentation
+## Project Documentation
 
 The [`README.md`][] in the root of the repository should contain or link to
 project documentation. If you cannot find the documentation you’re looking for,
 please file a GitHub issue with details of what you’d like to see documented.
 
-### Questions or Thoughts?
+## Questions or Thoughts?
 
 Support requests (e.g., asking questions) or feedback (e.g., constructive
 criticism) may be directed to the [`@OpenINF`][twitter-account] support account
 on Twitter.
 
-### Additional Resources
+## Additional Resources
 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 - [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
 - [GitHub Help](https://help.github.com)
 
-### Code of Conduct
+## Code of Conduct
 
 By participating in this project, you are expected to uphold our Code of
 Conduct. Please see the [`CODE_OF_CONDUCT.md`][] file for expected behavior.
 
-### Developer’s Certificate of Origin 1.1
+## Developer’s Certificate of Origin 1.1
 
 By making a contribution to this project, I certify that:
 
@@ -126,11 +126,11 @@ By making a contribution to this project, I certify that:
   redistributed consistent with this project or the open source license(s)
   involved.
 
-### Reporting Security Issues
+## Reporting Security Issues
 
 Please see the [`SECURITY.md`][] file.
 
-### Attribution
+## Attribution
 
 [Developer Certificate of Origin Legal Text](https://developercertificate.org/)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-## Security Policy[^1]
+# Security Policy[^1]
 
 The OpenINF SDK team, now benefitting from [dual Maintainership][], takes the
 security of OpenINF and the applications created with its SDK seriously. This
@@ -6,7 +6,7 @@ page describes how to report any vulnerabilities you may find and lists best
 practices to minimize the risk of introducing or being affected by a
 vulnerability.
 
-### Reporting Vulnerabilities
+## Reporting Vulnerabilities
 
 In the rare event that you find a vulnerability in the OpenINF SDK itself,
 [email us][]. We hope to regularly work with the cybersecurity community and the
@@ -16,7 +16,7 @@ shortly for those uncomfortable with that medium. Anonymous reports will also
 gladly be accepted. We also hope to introduce a healthy manner of incentivizing
 reporting in the near term.
 
-### Best Practices
+## Best Practices
 
 - **Keep current with the latest OpenINF SDK releases.** We regularly update the
   various packages that the OpenINF SDK is composed of, and these updates may

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,8 +1,8 @@
-## Support[^1]
+# Support[^1]
 
 Having trouble? Please consult these official resources in order of appearance.
 
-### Resources
+## Resources
 
 **[open.inf.is][docs-site] on the Web:** The OpenINF website. It has docs and
 tutorial resources.

--- a/VISION.md
+++ b/VISION.md
@@ -1,4 +1,4 @@
-## Vision[^1]
+# Vision[^1]
 
 The main motivations of OpenINF are to empower the open source community with
 tools to aggregate, curate, disseminate, and apply information derived from


### PR DESCRIPTION
## Pull Request Purpose

This PR contains the following:

- [x] 🐞🔧 bugfixing (🐜/🦟/🐛/🦗/🐝 et al.)
- [ ] 🆕🎏 implementation of new feature(s)
- [ ] ♻️ refactoring(s)
- [x] 📄 documentation modification(s)
- [ ] 🔮 other

### Testing

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Heading levels in Markdown; no code path to cover. Verified each file now has exactly one `h1` (so `MD025` stays satisfied) and that only heading lines are touched.

### Breaking Changes

- [ ] yes (_breaking changes will not be merged unless necessary_)
- [x] no

Anchors are generated from heading *text*, not level, so existing deep links keep working.

### Description

Every health file opened at `##` and hung its sections off that at `###`:

```markdown
## Support[^1]
### Resources
```

So the document title was a second-level heading and nothing in the file was ever first-level. `MD002` and `MD041` are both disabled in `.markdownlint.jsonc`, which is why this went unremarked.

This bites any consumer that lifts the title out of the document to render as the page heading, because the sections are then two levels below it. [openinf.github.io][] does exactly that — it imports these five files as pages and renders the title as the page's `h1`, leaving:

```html
<h1>Support • Frequently Asked Questions</h1>
<h3>Resources</h3>
```

which the W3C validator rejects: `The heading “h3” … follows the heading “h1” …, skipping 1 heading level.`

Promoting everything one level fixes it at the source. Each file now opens at `#`, sections sit at `##`, and the two subsections in `CONTRIBUTING.md` at `###` — which is also just how a standalone document is normally written, so these read no worse on GitHub.

| file | headings before | after |
| --- | --- | --- |
| `CODE_OF_CONDUCT.md` | 1×`##` | 1×`#` |
| `CONTRIBUTING.md` | 1×`##`, 9×`###`, 2×`####` | 1×`#`, 9×`##`, 2×`###` |
| `SECURITY.md` | 1×`##`, 2×`###` | 1×`#`, 2×`##` |
| `SUPPORT.md` | 1×`##`, 1×`###` | 1×`#`, 1×`##` |
| `VISION.md` | 1×`##` | 1×`#` |

> [!IMPORTANT]
> Please hold this until [openinf.github.io#1785][site-pr] is ready to land with it. That site's importer currently strips titles with a *global* regex (`/^## (.*)\n\n/gm`), which is harmless only while `##` appears once per file. Once sections are `##`, running that importer unchanged would strip every section heading out of the imported copy. The site PR fixes the importer to strip only the title; merging these together avoids the window.

Follows [#883][] and [#884][].

List of any relevant issue numbers: _none_

[openinf.github.io]: https://github.com/OpenINF/openinf.github.io
[site-pr]: https://github.com/OpenINF/openinf.github.io/pull/1785
[#883]: https://github.com/OpenINF/.github/pull/883
[#884]: https://github.com/OpenINF/.github/pull/884